### PR TITLE
fix: match correctly a group when using an encoded rule pattern

### DIFF
--- a/src/main/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicy.java
+++ b/src/main/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicy.java
@@ -71,8 +71,8 @@ public class DynamicRoutingPolicy {
     @OnRequest
     public void onRequest(Request request, Response response, ExecutionContext executionContext, PolicyChain policyChain) {
         try {
-            String decodedSubPath = URLDecoder.decode(request.pathInfo(), Charset.defaultCharset().name());
             String originalSubPath = request.pathInfo();
+            String decodedSubPath = URLDecoder.decode(originalSubPath, Charset.defaultCharset().name());
 
             LOGGER.debug("Dynamic routing for path {}", originalSubPath);
             Rule rule = null;
@@ -82,7 +82,7 @@ public class DynamicRoutingPolicy {
                 for (final Rule r : configuration.getRules()) {
                     final String p = executionContext.getTemplateEngine().getValue(r.getPattern(), String.class);
                     pattern = Pattern.compile(p);
-                    if (pattern.matcher(decodedSubPath).matches()) {
+                    if (pattern.matcher(decodedSubPath).matches() || pattern.matcher(originalSubPath).matches()) {
                         rule = r;
                         break;
                     }

--- a/src/test/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicyTest.java
@@ -391,4 +391,26 @@ public class DynamicRoutingPolicyTest {
         verify(policyChain).doNext(request, response);
         verify(executionContext).setAttribute(ExecutionContext.ATTR_REQUEST_ENDPOINT, "http://host1/%3Dbar");
     }
+
+    @Test
+    public void test_shouldDynamicRouting_singleMatchingRule_WithEncodedGroupAndEncodedPattern() {
+        // Prepare policy configuration
+        List<Rule> rules = new ArrayList<>();
+        rules.add(new Rule("(/%2377777)", "http://host1{#group[0]}"));
+
+        when(dynamicRoutingPolicyConfiguration.getRules()).thenReturn(rules);
+
+        // Prepare inbound request
+        when(request.pathInfo()).thenReturn("/%2377777");
+
+        // Prepare context
+        when(executionContext.getTemplateEngine()).thenReturn(TemplateEngine.templateEngine());
+
+        // Execute policy
+        dynamicRoutingPolicy.onRequest(request, response, executionContext, policyChain);
+
+        // Check results
+        verify(policyChain).doNext(request, response);
+        verify(executionContext).setAttribute(ExecutionContext.ATTR_REQUEST_ENDPOINT, "http://host1/%2377777");
+    }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/9107
https://gravitee.atlassian.net/browse/APIM-2103

**Description**

This PR is making possible to use an URL encoded rule pattern with a matching group. 

Currently, it is not possible to match an encoded pattern, as the decoded version of it is used to check if the expression matches.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.11.3-fix-routing-encoded-pattern-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-dynamic-routing/1.11.3-fix-routing-encoded-pattern-SNAPSHOT/gravitee-policy-dynamic-routing-1.11.3-fix-routing-encoded-pattern-SNAPSHOT.zip)
  <!-- Version placeholder end -->
