### PR TITLE
Apim 2140 dynamic routing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.5.0
+    gravitee: gravitee-io/gravitee@4.1.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.0</version>
+        <version>21.0.1</version>
     </parent>
 
     <properties>

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,3 +6,4 @@ class=io.gravitee.policy.dynamicrouting.DynamicRoutingPolicy
 type=policy
 category=others
 icon=dynamic-routing.svg
+proxy=REQUEST

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,9 +1,10 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:dynamicrouting:configuration:DynamicRoutingPolicyConfiguration",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
   "title": "Dynamic Routing",
   "description": "Route request to an other endpoint according to specified rules",
-  "properties" : {
+  "properties": {
     "rules" : {
       "title": "Routing rules",
       "description": "Ordered list of rules to apply to inbound request.",


### PR DESCRIPTION
**Issue**

related to APIM-2140

**Description**

* update circle-ci orb & gravitee-parent
* change schema form
* add execution phase
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.12.0-apim-2140-dynamic-routing-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-dynamic-routing/1.12.0-apim-2140-dynamic-routing-SNAPSHOT/gravitee-policy-dynamic-routing-1.12.0-apim-2140-dynamic-routing-SNAPSHOT.zip)
  <!-- Version placeholder end -->
