### PR TITLE
Bump up dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.1.0
+    gravitee: gravitee-io/gravitee@5
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,11 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
-    }
-  ]
+    "extends": ["config:base", "schedule:earlyMondays"],
+    "prConcurrentLimit": 3,
+    "rebaseWhen": "conflicted",
+    "packageRules": [
+        {
+            "matchDatasources": ["orb"],
+            "rangeStrategy": "replace"
+        }
+    ]
 }

--- a/README.adoc
+++ b/README.adoc
@@ -26,7 +26,8 @@ endif::[]
 |===
 | Plugin version | APIM version
 
-| Up to 1.x                   | All
+| 1.x                         | Up to APIM 4.7
+| 2.x                         | APIM 4.8 and later
 |===
 
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,52 @@
+#
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: "3"
+
+env:
+    APIM_GW_DISTRIBUTION_PATH: "{{.APIM_GW_DISTRIBUTION_PATH }}"
+    APIM_MAPI_DISTRIBUTION_PATH: "{{.APIM_MAPI_DISTRIBUTION_PATH }}"
+
+tasks:
+    build:
+        desc: "Build"
+        cmds:
+            - mvn clean install -DskipTests -Dskip.validation
+
+    copy:
+        desc: "Copy policy"
+        cmds:
+            - cp target/gravitee-policy-dynamic-routing-*.zip ${APIM_GW_DISTRIBUTION_PATH}/plugins
+            - cp target/gravitee-policy-dynamic-routing-*.zip ${APIM_MAPI_DISTRIBUTION_PATH}/plugins
+
+    clean:
+        desc: "Clean"
+        cmds:
+            - rm -f ${APIM_GW_DISTRIBUTION_PATH}/plugins/gravitee-policy-dynamic-routing-*.zip
+            - rm -f ${APIM_MAPI_DISTRIBUTION_PATH}/plugins/gravitee-policy-dynamic-routing-*.zip
+
+    lint:
+        desc: "Lint"
+        cmds:
+            - mvn prettier:write
+
+    all:
+        desc: "Clean, Build and copy"
+        cmds:
+            - task: clean
+            - task: lint
+            - task: build
+            - task: copy

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.1</version>
+        <version>23.5.0</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,6 @@
     <properties>
         <gravitee-apim.version>4.8.28</gravitee-apim.version>
 
-        <maven-plugin-prettier.version>0.19</maven-plugin-prettier.version>
-        <maven-plugin-prettier.prettierjava.version>2.1.0</maven-plugin-prettier.prettierjava.version>
         <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>
 
         <!-- Property used by the publication job in CI-->
@@ -172,22 +170,6 @@
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>${maven-plugin-prettier.version}</version>
-                <configuration>
-                    <prettierJavaVersion>${maven-plugin-prettier.prettierjava.version}</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -34,14 +34,8 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>3.0.2</gravitee-bom.version>
-        <gravitee-apim.version>3.20.2</gravitee-apim.version>
-        <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>2.0.0</gravitee-common.version>
-        <gravitee-expression-language.version>2.0.0</gravitee-expression-language.version>
+        <gravitee-apim.version>4.8.28</gravitee-apim.version>
 
-        <maven-plugin-assembly.version>3.5.0</maven-plugin-assembly.version>
         <maven-plugin-prettier.version>0.19</maven-plugin-prettier.version>
         <maven-plugin-prettier.prettierjava.version>2.1.0</maven-plugin-prettier.prettierjava.version>
         <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>
@@ -52,12 +46,11 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Gravitee dependencies -->
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
+                <groupId>io.gravitee.apim</groupId>
+                <artifactId>gravitee-apim-bom</artifactId>
+                <version>${gravitee-apim.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -69,28 +62,24 @@
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
-            <version>${gravitee-gateway-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
-            <version>${gravitee-policy-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.el</groupId>
             <artifactId>gravitee-expression-language</artifactId>
-            <version>${gravitee-expression-language.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.common</groupId>
             <artifactId>gravitee-common</artifactId>
-            <version>${gravitee-common.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -171,7 +160,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-plugin-assembly.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>

--- a/src/assembly/policy-assembly.xml
+++ b/src/assembly/policy-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicy.java
+++ b/src/main/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicy.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/dynamicrouting/configuration/DynamicRoutingPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/dynamicrouting/configuration/DynamicRoutingPolicyConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/dynamicrouting/configuration/Rule.java
+++ b/src/main/java/io/gravitee/policy/dynamicrouting/configuration/Rule.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,44 +1,39 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "additionalProperties": false,
-  "title": "Dynamic Routing",
-  "description": "Route request to an other endpoint according to specified rules",
-  "properties": {
-    "rules" : {
-      "title": "Routing rules",
-      "description": "Ordered list of rules to apply to inbound request.",
-      "type" : "array",
-      "items" : {
-        "type" : "object",
-        "title": "Rule",
-        "id" : "urn:jsonschema:io:gravitee:policy:dynamicrouting:configuration:Rule",
-        "properties" : {
-          "pattern" : {
-            "title": "Match expression",
-            "description": "Regular expression to match incoming path (Support EL).",
-            "type" : "string",
-            "x-schema-form": {
-              "expression-language": true
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "title": "Dynamic Routing",
+    "description": "Route request to an other endpoint according to specified rules",
+    "properties": {
+        "rules": {
+            "title": "Routing rules",
+            "description": "Ordered list of rules to apply to inbound request.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "title": "Rule",
+                "id": "urn:jsonschema:io:gravitee:policy:dynamicrouting:configuration:Rule",
+                "properties": {
+                    "pattern": {
+                        "title": "Match expression",
+                        "description": "Regular expression to match incoming path (Support EL).",
+                        "type": "string",
+                        "x-schema-form": {
+                            "expression-language": true
+                        }
+                    },
+                    "url": {
+                        "title": "Redirect to",
+                        "description": "The target endpoint (Support EL).",
+                        "type": "string",
+                        "x-schema-form": {
+                            "expression-language": true
+                        }
+                    }
+                },
+                "required": ["pattern", "url"]
             }
-          },
-          "url" : {
-            "title": "Redirect to",
-            "description": "The target endpoint (Support EL).",
-            "type" : "string",
-            "x-schema-form": {
-              "expression-language": true
-            }
-          }
-        },
-        "required": [
-          "pattern",
-          "url"
-        ]
-      }
-    }
-  },
-  "required": [
-    "rules"
-  ]
+        }
+    },
+    "required": ["rules"]
 }

--- a/src/test/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicyIntegrationTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicyIntegrationTest.java
@@ -52,7 +52,7 @@ public class DynamicRoutingPolicyIntegrationTest extends AbstractPolicyTest<Dyna
     @Override
     public void configureApi(Api api) {
         super.configureApi(api);
-        api.setExecutionMode(ExecutionMode.JUPITER);
+        api.setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
     }
 
     @BeforeAll

--- a/src/test/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicyIntegrationV3CompatibilityTest.java
+++ b/src/test/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicyIntegrationV3CompatibilityTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicyIntegrationV3Test.java
+++ b/src/test/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicyIntegrationV3Test.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/dynamicrouting/DynamicRoutingPolicyTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/dynamicrouting/configuration/DynamicRoutingPolicyConfigurationTest.java
+++ b/src/test/java/io/gravitee/policy/dynamicrouting/configuration/DynamicRoutingPolicyConfigurationTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/apis/v2/with_absolute_url.json
+++ b/src/test/resources/apis/v2/with_absolute_url.json
@@ -4,7 +4,7 @@
     "gravitee": "2.0.0",
     "proxy": {
         "context_path": "/with_absolute_url",
-        "groups" :[
+        "groups": [
             {
                 "name": "default-group",
                 "endpoints": [

--- a/src/test/resources/apis/v2/with_endpoint.json
+++ b/src/test/resources/apis/v2/with_endpoint.json
@@ -4,7 +4,7 @@
     "gravitee": "2.0.0",
     "proxy": {
         "context_path": "/with_endpoint",
-        "groups" :[
+        "groups": [
             {
                 "name": "default-group",
                 "endpoints": [

--- a/src/test/resources/io/gravitee/policy/dynamicrouting/configuration/configuration1.json
+++ b/src/test/resources/io/gravitee/policy/dynamicrouting/configuration/configuration1.json
@@ -1,8 +1,8 @@
 {
-  "rules": [
-    {
-      "pattern": "totototo",
-      "url": "http://localhost/product"
-    }
-  ]
+    "rules": [
+        {
+            "pattern": "totototo",
+            "url": "http://localhost/product"
+        }
+    ]
 }


### PR DESCRIPTION
**PR Description**

Bump up the core dependencies (gravitee-parent, gravitee-apim-bom, gravitee-orb), run prettier, license format, fix incompatible tests to make policy up to date 

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-bump-up-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-dynamic-routing/2.0.0-bump-up-dependencies-SNAPSHOT/gravitee-policy-dynamic-routing-2.0.0-bump-up-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
