### PR TITLE
feat: enable policy for mcp proxy on request phase

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -8,3 +8,4 @@ category=others
 icon=dynamic-routing.svg
 proxy=REQUEST
 message=REQUEST
+mcp_proxy=REQUEST


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/GMA-590

**Description**

Enable policy on request phase

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-enable-for-mcp-proxy-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-dynamic-routing/2.1.0-enable-for-mcp-proxy-SNAPSHOT/gravitee-policy-dynamic-routing-2.1.0-enable-for-mcp-proxy-SNAPSHOT.zip)
  <!-- Version placeholder end -->
